### PR TITLE
Don't change iskeyword

### DIFF
--- a/syntax/nginx.vim
+++ b/syntax/nginx.vim
@@ -5,10 +5,6 @@ if exists("b:current_syntax")
   finish
 end
 
-setlocal iskeyword+=.
-setlocal iskeyword+=/
-setlocal iskeyword+=:
-
 syn match ngxVariable '\$\(\w\+\|{\w\+}\)'
 syn match ngxVariableString '\$\(\w\+\|{\w\+}\)' contained
 syn match ngxComment ' *#.*$'


### PR DESCRIPTION
Per https://stackoverflow.com/questions/17105272/wrong-word-boundaries-in-nginx-files-with-vim
There is no reason for syntax to update `iskeyword` setting.